### PR TITLE
Enabling Smp

### DIFF
--- a/src/training/data.py
+++ b/src/training/data.py
@@ -5,10 +5,11 @@ import math
 import os
 import random
 import sys
-import braceexpand
+import time
 from dataclasses import dataclass
 from multiprocessing import Value
 
+import braceexpand
 import numpy as np
 import pandas as pd
 import torch
@@ -24,6 +25,9 @@ try:
     import horovod.torch as hvd
 except ImportError:
     hvd = None
+
+from open_clip import tokenize
+from open_clip.tokenizer import HFTokenizer
 
 
 class CsvDataset(Dataset):
@@ -71,31 +75,9 @@ class DataInfo:
             self.sampler.set_epoch(epoch)
 
 
-def expand_urls(urls, weights=None):
-    if weights is None:
-        expanded_urls = wds.shardlists.expand_urls(urls)
-        return expanded_urls, None
-    if isinstance(urls, str):
-        urllist = urls.split("::")
-        weights = weights.split('::')
-        assert len(weights) == len(urllist),\
-            f"Expected the number of data components ({len(urllist)}) and weights({len(weights)}) to match."
-        weights = [float(weight) for weight in weights]
-        all_urls, all_weights = [], []
-        for url, weight in zip(urllist, weights):
-            expanded_url = list(braceexpand.braceexpand(url))
-            expanded_weights = [weight for _ in expanded_url]
-            all_urls.extend(expanded_url)
-            all_weights.extend(expanded_weights)
-        return all_urls, all_weights
-    else:
-        all_urls = list(urls)
-        return all_urls, weights
-
-
 def get_dataset_size(shards):
-    shards_list, _ = expand_urls(shards)
-    dir_path = os.path.dirname(shards_list[0])
+    shards_list = list(braceexpand.braceexpand(shards))
+    dir_path = os.path.dirname(shards)
     sizes_filename = os.path.join(dir_path, 'sizes.json')
     len_filename = os.path.join(dir_path, '__len__')
     if os.path.exists(sizes_filename):
@@ -172,13 +154,11 @@ def count_samples(dataloader):
 
 
 def filter_no_caption_or_no_image(sample):
-    has_caption = ('txt' in sample)
-    has_image = ('png' in sample or 'jpg' in sample or 'jpeg' in sample or 'webp' in sample)
-    return has_caption and has_image
+    return ('txt' in sample) and ('png' in sample or 'jpg' in sample)
 
 
 def log_and_continue(exn):
-    """Call in an exception handler to ignore any exception, issue a warning, and continue."""
+    """Call in an exception handler to ignore any exception, isssue a warning, and continue."""
     logging.warning(f'Handling webdataset error ({repr(exn)}). Ignoring.')
     return True
 
@@ -219,16 +199,12 @@ def tarfile_to_samples_nothrow(src, handler=log_and_continue):
     return samples
 
 
-def pytorch_worker_seed(increment=0):
+def pytorch_worker_seed():
     """get dataloader worker seed from pytorch"""
     worker_info = get_worker_info()
     if worker_info is not None:
-        # favour using the seed already created for pytorch dataloader workers if it exists
-        seed = worker_info.seed
-        if increment:
-            # space out seed increments so they can't overlap across workers in different iterations
-            seed += increment * max(1, worker_info.num_workers)
-        return seed
+        # favour the seed already created for pytorch dataloader workers if it exists
+        return worker_info.seed
     # fallback to wds rank based seed
     return wds.utils.pytorch_worker_seed()
 
@@ -262,10 +238,8 @@ class detshuffle2(wds.PipelineStage):
             epoch = self.epoch
         rng = random.Random()
         if self.seed < 0:
-            # If seed is negative, we use the worker's seed, this will be different across all nodes/workers
-            seed = pytorch_worker_seed(epoch)
+            seed = pytorch_worker_seed() + epoch
         else:
-            # This seed to be deterministic AND the same across all nodes/workers in each epoch
             seed = self.seed + epoch
         rng.seed(seed)
         return _shuffle(src, self.bufsize, self.initial, rng)
@@ -277,7 +251,6 @@ class ResampledShards2(IterableDataset):
     def __init__(
         self,
         urls,
-        weights=None,
         nshards=sys.maxsize,
         worker_seed=None,
         deterministic=False,
@@ -288,16 +261,12 @@ class ResampledShards2(IterableDataset):
         :param urls: a list of URLs as a Python list or brace notation string
         """
         super().__init__()
-        urls, weights = expand_urls(urls, weights)
+        urls = wds.shardlists.expand_urls(urls)
         self.urls = urls
-        self.weights = weights
-        if self.weights is not None:
-            assert len(self.urls) == len(self.weights),\
-                f"Number of urls {len(self.urls)} and weights {len(self.weights)} should match."
         assert isinstance(self.urls[0], str)
         self.nshards = nshards
         self.rng = random.Random()
-        self.worker_seed = worker_seed
+        self.worker_seed = pytorch_worker_seed if worker_seed is None else worker_seed
         self.deterministic = deterministic
         self.epoch = epoch
 
@@ -311,18 +280,10 @@ class ResampledShards2(IterableDataset):
             self.epoch += 1
             epoch = self.epoch
         if self.deterministic:
-            # reset seed w/ epoch if deterministic
-            if self.worker_seed is None:
-                # pytorch worker seed should be deterministic due to being init by arg.seed + rank + worker id
-                seed = pytorch_worker_seed(epoch)
-            else:
-                seed = self.worker_seed() + epoch
-            self.rng.seed(seed)
+            # reset seed w/ epoch if deterministic, worker seed should be deterministic due to arg.seed
+            self.rng.seed(self.worker_seed() + epoch)
         for _ in range(self.nshards):
-            if self.weights is None:
-                yield dict(url=self.rng.choice(self.urls))
-            else:
-                yield dict(url=self.rng.choices(self.urls, weights=self.weights, k=1)[0])
+            yield dict(url=self.rng.choice(self.urls))
 
 
 def get_wds_dataset(args, preprocess_img, is_train, epoch=0, floor=False, tokenizer=None):
@@ -330,32 +291,21 @@ def get_wds_dataset(args, preprocess_img, is_train, epoch=0, floor=False, tokeni
     assert input_shards is not None
     resampled = getattr(args, 'dataset_resampled', False) and is_train
 
-    num_shards = None
-    if is_train:
-        if args.train_num_samples is not None:
+    num_samples, num_shards = get_dataset_size(input_shards)
+    if not num_samples:
+        if is_train:
             num_samples = args.train_num_samples
-        else:
-            num_samples, num_shards = get_dataset_size(input_shards)
             if not num_samples:
                 raise RuntimeError(
-                    'Currently, the number of dataset samples must be specified for the training dataset. '
-                    'Please specify it via `--train-num-samples` if no dataset length info is present.')
-    else:
-        # Eval will just exhaust the iterator if the size is not specified.
-        num_samples = args.val_num_samples or 0 
+                    'Currently, number of dataset samples must be specified for training dataset. '
+                    'Please specify via `--train-num-samples` if no dataset length info present.')
+        else:
+            num_samples = args.val_num_samples or 0  # eval will just exhaust the iterator if not specified
 
     shared_epoch = SharedEpoch(epoch=epoch)  # create a shared epoch store to sync epoch to dataloader worker proc
-    
     if resampled:
-        pipeline = [ResampledShards2(
-            input_shards,
-            weights=args.train_data_upsampling_factors,
-            deterministic=True,
-            epoch=shared_epoch,
-        )]
+        pipeline = [ResampledShards2(input_shards, deterministic=True, epoch=shared_epoch)]
     else:
-        assert args.train_data_upsampling_factors is None,\
-            "--train_data_upsampling_factors is only supported when sampling with replacement (with --dataset-resampled)."
         pipeline = [wds.SimpleShardList(input_shards)]
 
     # at this point we have an iterator over all the shards
@@ -388,17 +338,15 @@ def get_wds_dataset(args, preprocess_img, is_train, epoch=0, floor=False, tokeni
     pipeline.extend([
         wds.select(filter_no_caption_or_no_image),
         wds.decode("pilrgb", handler=log_and_continue),
-        wds.rename(image="jpg;png;jpeg;webp", text="txt"),
+        wds.rename(image="jpg;png", text="txt"),
         wds.map_dict(image=preprocess_img, text=lambda text: tokenizer(text)[0]),
         wds.to_tuple("image", "text"),
-        wds.batched(args.batch_size, partial=not is_train)
+        wds.batched(args.batch_size, partial=not is_train),
     ])
 
     dataset = wds.DataPipeline(*pipeline)
-
     if is_train:
         if not resampled:
-            num_shards = num_shards or len(expand_urls(input_shards)[0])
             assert num_shards >= args.workers * args.world_size, 'number of shards must be >= total workers'
         # roll over and repeat a few samples to get same number of full batches on each node
         round_fn = math.floor if floor else math.ceil
@@ -451,8 +399,7 @@ def get_csv_dataset(args, preprocess_fn, is_train, epoch=0, tokenizer=None):
         img_key=args.csv_img_key,
         caption_key=args.csv_caption_key,
         sep=args.csv_separator,
-        tokenizer=tokenizer
-    )
+		tokenizer=tokenizer)
     num_samples = len(dataset)
     sampler = DistributedSampler(dataset) if args.distributed and is_train else None
     shuffle = is_train and sampler is None
@@ -471,17 +418,9 @@ def get_csv_dataset(args, preprocess_fn, is_train, epoch=0, tokenizer=None):
 
     return DataInfo(dataloader, sampler)
 
-
 class SyntheticDataset(Dataset):
 
-    def __init__(
-            self,
-            transform=None,
-            image_size=(224, 224),
-            caption="Dummy caption",
-            dataset_size=100,
-            tokenizer=None,
-    ):
+    def __init__(self, transform=None, image_size=(224, 224), caption="Dummy caption", dataset_size=100, tokenizer=None):
         self.transform = transform
         self.image_size = image_size
         self.caption = caption
@@ -521,7 +460,6 @@ def get_synthetic_dataset(args, preprocess_fn, is_train, epoch=0, tokenizer=None
 
     return DataInfo(dataloader, sampler)
 
-
 def get_dataset_fn(data_path, dataset_type):
     if dataset_type == "webdataset":
         return get_wds_dataset
@@ -537,7 +475,7 @@ def get_dataset_fn(data_path, dataset_type):
             return get_wds_dataset
         else:
             raise ValueError(
-                f"Tried to figure out dataset type, but failed for extension {ext}.")
+                f"Tried to figure out dataset type, but failed for extention {ext}.")
     else:
         raise ValueError(f"Unsupported dataset type: {dataset_type}")
     

--- a/src/training/data.py
+++ b/src/training/data.py
@@ -77,6 +77,7 @@ class DataInfo:
 
 def get_dataset_size(shards):
     shards_list = list(braceexpand.braceexpand(shards))
+    print(shards_list)
     dir_path = os.path.dirname(shards)
     sizes_filename = os.path.join(dir_path, 'sizes.json')
     len_filename = os.path.join(dir_path, '__len__')
@@ -288,6 +289,7 @@ class ResampledShards2(IterableDataset):
 
 def get_wds_dataset(args, preprocess_img, is_train, epoch=0, floor=False, tokenizer=None):
     input_shards = args.train_data if is_train else args.val_data
+    print(input_shards)
     assert input_shards is not None
     resampled = getattr(args, 'dataset_resampled', False) and is_train
 
@@ -347,7 +349,7 @@ def get_wds_dataset(args, preprocess_img, is_train, epoch=0, floor=False, tokeni
     dataset = wds.DataPipeline(*pipeline)
     if is_train:
         if not resampled:
-            assert num_shards >= args.workers * args.world_size, 'number of shards must be >= total workers'
+            assert num_shards >= args.workers * args.world_size, f'number of shards must be >= total workers {num_shards}, {args.workers}, {args.world_size}'
         # roll over and repeat a few samples to get same number of full batches on each node
         round_fn = math.floor if floor else math.ceil
         global_batch_size = args.batch_size * args.world_size

--- a/src/training/params.py
+++ b/src/training/params.py
@@ -275,6 +275,8 @@ def parse_args(args):
         action="store_true",
         help="Use horovod for distributed training."
     )
+    parser.add_argument("--smp", default=False, action="store_true")
+    parser.add_argument("--sharded_data_parallel_degree", default=1, type=int)
     parser.add_argument(
         "--ddp-static-graph",
         default=False,


### PR DESCRIPTION


Below changes show how to integrate SMP into the OpenClip training script. Currently it only does changes for training, evaluation needs similar changes.

Notably the following main changes

-    Init SMP similar to what is done for Horovod in this script.
-    Wrappers for model and optimizer.
-    The style of mixed precision is different with SMP. Instead of using amp/autocast/gradScaler, we have our own mixed precision within SMP which can be activated by setting flag for dtype when initializing SMP. The layernormFp32 in this repo is not compatible with that as the weight would be in half precision in SMP. Changing to SMP's LayerNorm can address this issue.
-    There are couple of instances in the model, where a module works on params that were not created in its own module. With Sharded data parallelism in SMP we need to register these parameters so they are gathered before execution.
-    Some API changes for checkpointing, so we can handle the sharded states across GPUs.
-    Training script needs to be encapsulated within smp.step annotated function and model.backward needs to be called for backward.

